### PR TITLE
Swaps atob and btoa. Fixes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Note that if you provide invalid base64 strings, your text will ben replaced by 
 
 After replacement, the new text will automatically be visually selected.
 
-* `<leader>btoa` to convert from base64 to a string
-* `<leader>atob` to convert from a string to base64
+* `<leader>atob` to convert from base64 to a string
+* `<leader>btoa` to convert from a string to base64
 
 # Contributions
 

--- a/plugin/base64.vim
+++ b/plugin/base64.vim
@@ -1,7 +1,7 @@
 " Visual Mode mappings
-vnoremap <silent> <leader>btoa c<c-r>=base64#decode(@")<cr><esc>`[v`]h
-vnoremap <silent> <leader>atob c<c-r>=base64#encode(@")<cr><esc>`[v`]h
+vnoremap <silent> <leader>atob c<c-r>=base64#decode(@")<cr><esc>`[v`]h
+vnoremap <silent> <leader>btoa c<c-r>=base64#encode(@")<cr><esc>`[v`]h
 
 " Regex mappings
-nnoremap <leader>atob/ :%s/\v()/\=base64#encode(submatch(1))/<home><right><right><right><right><right><right>
-nnoremap <leader>btoa/ :%s/\v()/\=base64#decode(submatch(1))/<home><right><right><right><right><right><right>
+nnoremap <leader>btoa/ :%s/\v()/\=base64#encode(submatch(1))/<home><right><right><right><right><right><right>
+nnoremap <leader>atob/ :%s/\v()/\=base64#decode(submatch(1))/<home><right><right><right><right><right><right>

--- a/tests/visual-decode.vader
+++ b/tests/visual-decode.vader
@@ -3,7 +3,7 @@ Given (an encoded string):
 
 Do (visual decode):
   f>lvt<
-  \<space>btoa
+  \<space>atob
 
 Expect (decoded string):
   <value>Abc123</value>

--- a/tests/visual-encode.vader
+++ b/tests/visual-encode.vader
@@ -3,7 +3,7 @@ Given (a string):
 
 Do (visual encode):
   f>lvt<
-  \<space>atob
+  \<space>btoa
 
 Expect (encoded string):
   <value>QWJjMTIz</value>

--- a/tests/visual-keeps-selection.vader
+++ b/tests/visual-keeps-selection.vader
@@ -3,10 +3,10 @@ Given (a string):
 
 Do (go back and forth):
   lv
-  \<space>atob
   \<space>btoa
   \<space>atob
   \<space>btoa
+  \<space>atob
 
 Expect (that text was still visually selected):
   abc


### PR DESCRIPTION
Source: https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding

> The atob() function decodes a string of data which has been encoded using base-64 encoding. Conversely, the btoa() function creates a base-64 encoded ASCII string from a "string" of binary data.

I had trouble getting Vader.vim to run the tests, but I did update them to reflect the changes I made.
Hopefully that still checks out.